### PR TITLE
allow configuration of port and fix static files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 *.pyc
+*sqlite3
+staticfiles
+

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn helloworld.wsgi
+web: gunicorn --bind 0.0.0.0:${PORT:-8000} helloworld.wsgi

--- a/helloworld/settings.py
+++ b/helloworld/settings.py
@@ -80,4 +80,4 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/1.6/howto/static-files/
 
 STATIC_URL = '/static/'
-STATIC_ROOT = os.path.join(BASE_DIR, 'static')
+STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')

--- a/helloworld/wsgi.py
+++ b/helloworld/wsgi.py
@@ -11,4 +11,5 @@ import os
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "helloworld.settings")
 
 from django.core.wsgi import get_wsgi_application
-application = get_wsgi_application()
+from dj_static import Cling
+application = Cling(get_wsgi_application())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 Django==1.6.5
 gunicorn==18.0
+dj-static==0.0.6
+static==1.0.2


### PR DESCRIPTION
There was no way to set the port number, plus gunicorn seemed to always bind to 127.0.0.1
